### PR TITLE
a proposed fix to search for duplicate fims fields

### DIFF
--- a/src/com/biomatters/plugins/biocode/assembler/annotate/AnnotateUtilities.java
+++ b/src/com/biomatters/plugins/biocode/assembler/annotate/AnnotateUtilities.java
@@ -100,7 +100,9 @@ public class AnnotateUtilities {
 
         for (AnnotatedPluginDocument annotatedDocument : docsAnnotated) {
             for (DocumentField field : annotatedDocument.getDisplayableFields()) {
-                if(field.getCode().startsWith(MySQLFimsConnection.FIELD_PREFIX) || Pattern.matches("\\d+", field.getCode())) {
+                //if(field.getCode().startsWith(MySQLFimsConnection.FIELD_PREFIX) || Pattern.matches("\\d+", field.getCode())) {
+                // Only search for old fields containing urn:
+                if(field.getCode().contains("urn:"))  {
                     if(annotatedDocument.getFieldValue(field) != null) {
                         oldFields.add(field);
                     }


### PR DESCRIPTION
I commented out a line that seemed to be preventing the annotation utilities from searching for duplicate fields and replaced it with something that works for the GEOME and BiSciCol FIMS variants.  However, i'm not sure of its impact on other FIMS.  So, while the code here works for my testing environment it may also break other uses.... 